### PR TITLE
Adding missing details for Maven central

### DIFF
--- a/dione-spark/src/main/java/com/paypal/dione/DummyDoc.java
+++ b/dione-spark/src/main/java/com/paypal/dione/DummyDoc.java
@@ -1,0 +1,7 @@
+package com.paypal.dione;
+
+/**
+ * Sonatype enforces javadoc artifact to get created, so we need a Java file in the project.
+ */
+public class DummyDoc {
+}

--- a/pom.xml
+++ b/pom.xml
@@ -215,32 +215,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <!-- unpack the resources from my dependent jars as part of the build -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
@@ -272,6 +246,17 @@
                     <deployAtEnd>true</deployAtEnd>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.7</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -280,6 +265,32 @@
             <id>publish</id>
             <build>
                 <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>2.2.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>2.9.1</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,12 @@
 
     <groupId>com.paypal.dione</groupId>
     <artifactId>dione-parent</artifactId>
+    <name>Dione</name>
+    <description>an HDFS indexing library</description>
+    <url>https://github.com/paypal/dione</url>
+
     <version>0.5.0</version>
+
     <packaging>pom</packaging>
 
     <properties>


### PR DESCRIPTION
# Summary
our checks have failed.
we need to enforce the creation of javadoc artifact for dione-spark although it is scala only.
also adding some missing details in the pom.xml