### PR TITLE
Parquet index

### DIFF
--- a/dione-spark/src/main/scala/com/paypal/dione/spark/avro/btree/SparkAvroBtreeUtils.scala
+++ b/dione-spark/src/main/scala/com/paypal/dione/spark/avro/btree/SparkAvroBtreeUtils.scala
@@ -23,7 +23,7 @@ object SparkAvroBtreeUtils {
 
   private val logger = LoggerFactory.getLogger(this.getClass)
   val KEY_HASH_COLUMN = "keyhash"
-  private val PARTITION_HASH_COLUMN = "prthash"
+  val PARTITION_HASH_COLUMN = "prthash"
 
   /**
    * Save a Spark DataFrame as AvroBtreeFiles, so later we'll be able to leverage that for a few use-cases.
@@ -45,7 +45,9 @@ object SparkAvroBtreeUtils {
                          numFilesInFolder: Int, interval: Int, height: Int,
                          mode: String = "overwrite"
                         )(implicit spark: SparkSession): Unit = {
-    writePartitionedDFasAvroBtree(df, keys, folderName, interval, height, Seq((Nil, numFilesInFolder)), mode)
+    val partitionsSpec = Seq((Nil, numFilesInFolder))
+    val repartitionedDF = IndexManagerUtils.customRepartition(df, keys, partitionsSpec)
+    writePartitionedDFasAvroBtree(repartitionedDF, keys, folderName, interval, height, partitionsSpec, mode)
   }
 
   /**
@@ -69,9 +71,8 @@ object SparkAvroBtreeUtils {
     logger.info("writing index file to " + folderName + s" with interval: $interval, height: $height," +
       s" partitionsSpec: $partitionsSpec")
 
-    val repartitionedDF = customRepartition(df, keys, partitionsSpec)
 
-    repartitionedDF
+    df
       .write
       .partitionBy(partitionKeys:_*)
       .mode(mode)
@@ -125,7 +126,7 @@ object SparkAvroBtreeUtils {
     val outputSchema = StructType(dsDF.schema ++ indexTableValueSchema)
 
     // repartition the dsDF using our customRepartition to get the matching partitions
-    val repartitionedDF = SparkAvroBtreeUtils.customRepartition(filteredDsDf, keys, partitionsSpecWithNumFiles)
+    val repartitionedDF = IndexManagerUtils.customRepartition(filteredDsDf, keys, partitionsSpecWithNumFiles)
 
     // on-the-fly join between the matching partitions. both sides are sorted, so we just "merge-join" them
     val joinedDF = repartitionedDF.mapPartitions((it: Iterator[Row]) =>
@@ -168,60 +169,4 @@ object SparkAvroBtreeUtils {
     joinedDF
   }
 
-  /**
-   * This is a custom partitioner. shuffles the data according to the keys and partition keys.
-   * Each partitionSpec contains the number of files its rows will be shuffled to, and each file will contain
-   * only keys with the same hash value. Also, files will be sorted by the keys.
-   *
-   * @param partitionsSpec static partitions definition. each entry contain the (key->value) list of a specific
-   *                       partition and number of files the partition's folder.
-   * @return repartitioned DataFrame where each partition contains only rows of the same hashkey and partition.
-   */
-  def customRepartition(df: DataFrame, keys: Seq[String],
-                        partitionsSpec: Seq[(Seq[(String, String)], Int)]): DataFrame = {
-
-    val dupPartitionValues = partitionsSpec.map(_._1).groupBy(identity).map(t => (t._1, t._2.size)).filter(_._2 > 1).keys
-    assert(dupPartitionValues.isEmpty, "Found duplicated partitions: " + dupPartitionValues)
-
-    val partitionKeys = partitionsSpec.flatMap(_._1.map(_._1)).distinct
-
-    val spark = df.sparkSession
-
-    val hashudf = spark.udf.register("hashudf",
-      AvroHashBtreeStorageFolderReader.hashModuloUdf(_: mutable.WrappedArray[String], _: Int))
-
-    // static map from partition values to (num_of_files, cumsum_num_of_files)
-    var s = 0
-    val prtsIndex: Map[Seq[String], (Int, Int)] = partitionsSpec.map(sq => {
-      val sqMap = sq._1.toMap
-      (partitionKeys.map(sqMap), sq._2)
-    }).zipWithIndex.map(t => {s+=t._1._2; (t._1._1, (t._1._2, s-t._1._2))}).toMap
-
-    val prtudf = spark.udf.register("prtudf", (prtSpec: mutable.WrappedArray[String]) =>
-      prtsIndex.getOrElse(prtSpec, (0,0)))
-
-    // for each "static" partition, we would like to have numFilesInPartition files.
-    // and because each task creates one file, we want (numFilesInPartition * numOfPartitions) tasks.
-    // moreover, we want to decide which rows are in each task, so in the reader we would know in which
-    // file to find every key.
-    val dfWithHashes = df
-      .withColumn(PARTITION_HASH_COLUMN, prtudf(array(partitionKeys.map(col): _*)))
-      .withColumn(KEY_HASH_COLUMN, hashudf(array(keys.map(col): _*), expr("prthash._1")))
-
-    val customPartitionedRDD = dfWithHashes
-      .rdd
-      .map(row => ((row.getAs[Int](KEY_HASH_COLUMN), row.getAs[Row](PARTITION_HASH_COLUMN).get(1)), row))
-      .partitionBy(new Partitioner {
-        override def numPartitions: Int = prtsIndex.values.map(_._1).sum
-
-        override def getPartition(key: Any): Int = {
-          val (hashKeyMod, prtCumSum) = key.asInstanceOf[(Int, Int)]
-          prtCumSum + hashKeyMod
-        }
-
-      })
-
-    spark.createDataFrame(customPartitionedRDD.map(_._2), dfWithHashes.schema)
-      .sortWithinPartitions((partitionKeys ++ keys).map(col):_*)
-  }
 }

--- a/dione-spark/src/main/scala/com/paypal/dione/spark/avro/btree/SparkAvroBtreeUtils.scala
+++ b/dione-spark/src/main/scala/com/paypal/dione/spark/avro/btree/SparkAvroBtreeUtils.scala
@@ -66,11 +66,14 @@ object SparkAvroBtreeUtils {
 
     val keysSet = keys.toSet
     val partitionKeys = partitionsSpec.flatMap(_._1.map(_._1)).distinct
-    val remainingColumns = df.columns.filterNot(c => keysSet.contains(c) || partitionKeys.contains(c))
+
+    def isReservedColumn(c: String) =
+      keysSet.contains(c) || partitionKeys.contains(c) || c == PARTITION_HASH_COLUMN || c == KEY_HASH_COLUMN
+
+    val remainingColumns = df.columns.filterNot(isReservedColumn)
 
     logger.info("writing index file to " + folderName + s" with interval: $interval, height: $height," +
       s" partitionsSpec: $partitionsSpec")
-
 
     df
       .write

--- a/dione-spark/src/main/scala/com/paypal/dione/spark/index/IndexManager.scala
+++ b/dione-spark/src/main/scala/com/paypal/dione/spark/index/IndexManager.scala
@@ -210,7 +210,7 @@ case class IndexManager(@transient val spark: SparkSession, sparkIndexer: SparkI
         val valueOpt = avroHashBtreeFolderReader.get(key)
         valueOpt.map(readPayload(_, fields))
       case _ =>
-        throw new RuntimeException("Fetch is not supported with index type " + indexType.getClass.getName)
+        throw new UnsupportedOperationException("Fetch is not supported with index type " + indexType.getClass.getName)
     }
 
   }

--- a/dione-spark/src/main/scala/com/paypal/dione/spark/index/IndexManager.scala
+++ b/dione-spark/src/main/scala/com/paypal/dione/spark/index/IndexManager.scala
@@ -9,8 +9,31 @@ import org.apache.spark.sql.functions.{col, expr}
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
+sealed trait IndexType {
+  val storeName: String
+}
+
+object IndexType {
+
+  def parse(from: String) = from match {
+    case AvroBTree.storeName => AvroBTree
+    case Parquet.storeName => Parquet
+    case _=> throw new RuntimeException("Unrecognized index type: " + from)
+  }
+
+  case object AvroBTree extends IndexType {
+    override val storeName: String = "avro"
+  }
+
+  case object Parquet extends IndexType {
+    override val storeName: String = "parquet"
+  }
+
+}
+
 case class IndexSpec(dataTableName: String, indexTableName: String,
-                     keys: Seq[String], moreFields: Seq[String] = Nil)
+                     keys: Seq[String], moreFields: Seq[String] = Nil,
+                     indexType: IndexType = IndexType.AvroBTree)
 
 object IndexManager {
 
@@ -57,8 +80,9 @@ object IndexManager {
 
     val dataTableName = tblProperties("index.meta.dataTableName")
     val keys = tblProperties("index.meta.keys").split("\\|")
+    val indexType = IndexType.parse(tblProperties.getOrElse("index.meta.type", "avro_btree"))
     val moreFields = tblProperties("index.meta.moreFields").split("\\|").filterNot(_.isEmpty)
-    val indexSpec = IndexSpec(dataTableName, indexTableName, keys, moreFields)
+    val indexSpec = IndexSpec(dataTableName, indexTableName, keys, moreFields, indexType)
 
     // TODO - add the manager class to the table metadata, and pass explicitly here:
     val indexManager: IndexManager = IndexManagerUtils.createIndexManager(spark, indexSpec)
@@ -82,7 +106,7 @@ object IndexManager {
 case class IndexManager(@transient val spark: SparkSession, sparkIndexer: SparkIndexer,
                         indexSpec: IndexSpec) extends Serializable {
 
-  val IndexSpec(dataTableName, indexTableName, keys, moreFields) = indexSpec
+  val IndexSpec(dataTableName, indexTableName, keys, moreFields, indexType) = indexSpec
 
   lazy val indexFolder: String = {
     val descFormattedIndex = spark.sql(s"desc formatted $indexTableName").collect()
@@ -136,8 +160,22 @@ case class IndexManager(@transient val spark: SparkSession, sparkIndexer: SparkI
       .drop(PARTITION_DEF_COLUMN)
 
     val partitionsSpecWithNumParts = partitionsSpec.map(t => (t, numParts))
-    SparkAvroBtreeUtils.writePartitionedDFasAvroBtree(indexWithPrtCols, keys, indexFolder,
-      indexInterval, height, partitionsSpecWithNumParts, "append")(spark)
+    val repartitionedDF = IndexManagerUtils.customRepartition(indexWithPrtCols, keys, partitionsSpecWithNumParts)
+    indexType match {
+      case IndexType.AvroBTree =>
+        SparkAvroBtreeUtils.writePartitionedDFasAvroBtree(repartitionedDF, keys, indexFolder,
+          indexInterval, height, partitionsSpecWithNumParts, "append")(spark)
+      case IndexType.Parquet =>
+        val columns = spark.table(indexTableName).columns
+        // drop intermediate columns:
+        val select = repartitionedDF.columns.filter(columns.contains).map(col)
+        val strict = spark.conf.get("hive.exec.dynamic.partition.mode", null)
+        spark.conf.set("hive.exec.dynamic.partition.mode", "nonstrict")
+        repartitionedDF.select(select: _*).write.insertInto(indexTableName)
+        if (strict == null) spark.conf.unset("hive.exec.dynamic.partition.mode")
+        else spark.conf.set("hive.exec.dynamic.partition.mode", strict)
+    }
+
 
     spark.sql("msck repair table " + indexTableName)
     spark.sql(s"alter table $indexTableName set TBLPROPERTIES ('avro.schema.url'='$indexFolder/.btree.avsc')")
@@ -165,10 +203,16 @@ case class IndexManager(@transient val spark: SparkSession, sparkIndexer: SparkI
    * @return The Record as Map
    */
   def fetch(key: Seq[Any], partitionSpec: Seq[(String, String)], fields: Option[Seq[String]] = None): Option[Map[String, Any]] = {
-    val partitionFolder = indexFolder + "/" + getPartitionFolder(partitionSpec)
-    val avroHashBtreeFolderReader = AvroHashBtreeStorageFolderReader(partitionFolder)
-    val valueOpt = avroHashBtreeFolderReader.get(key)
-    valueOpt.map(readPayload(_, fields))
+    indexType match {
+      case IndexType.AvroBTree =>
+        val partitionFolder = indexFolder + "/" + getPartitionFolder(partitionSpec)
+        val avroHashBtreeFolderReader = AvroHashBtreeStorageFolderReader(partitionFolder)
+        val valueOpt = avroHashBtreeFolderReader.get(key)
+        valueOpt.map(readPayload(_, fields))
+      case _ =>
+        throw new RuntimeException("Fetch is not supported with index type " + indexType.getClass.getName)
+    }
+
   }
 
   /**

--- a/dione-spark/src/test/scala/com/paypal/dione/spark/index/avro/TestAvroIndexManager.scala
+++ b/dione-spark/src/test/scala/com/paypal/dione/spark/index/avro/TestAvroIndexManager.scala
@@ -6,7 +6,7 @@ import com.paypal.dione.hdfs.index.HdfsIndexerMetadata
 import com.paypal.dione.hdfs.index.avro.AvroIndexer
 import com.paypal.dione.kvstorage.hadoop.avro.AvroHashBtreeStorageFolderReader
 import com.paypal.dione.spark.avro.btree.SparkAvroBtreeUtils
-import com.paypal.dione.spark.index.{IndexManager, IndexManagerUtils, IndexSpec}
+import com.paypal.dione.spark.index.{IndexManager, IndexManagerUtils, IndexSpec, IndexType}
 import org.apache.hadoop.fs.Path
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation
 import org.junit.jupiter.api._
@@ -34,14 +34,15 @@ object TestAvroIndexManager extends SparkCleanTestDB {
 }
 
 @TestMethodOrder(classOf[OrderAnnotation])
-class TestAvroIndexManager {
+abstract class TestAvroIndexManager {
+  val indexType: IndexType
 
   import TestAvroIndexManager._
 
   @Test
   @Order(1)
   def testCreateIndexManager(): Unit = {
-    IndexManager.createNew(IndexSpec("t3", "index_t3", Seq("message_id", "sub_message_id"), Seq("time_result_created")))(spark)
+    IndexManager.createNew(IndexSpec("t3", "index_t3", Seq("message_id", "sub_message_id"), Seq("time_result_created"), indexType))(spark)
     spark.sql("desc formatted index_t3").show(100, false)
   }
 
@@ -128,4 +129,11 @@ class TestAvroIndexManager {
     Assertions.assertEquals(None, kvGetter.get(Seq("msg_119")))
   }
 
+}
+
+class AvroAvro extends TestAvroIndexManager {
+  override val indexType: IndexType = IndexType.AvroBTree
+}
+class AvroParquet extends TestAvroIndexManager {
+  override val indexType: IndexType = IndexType.Parquet
 }


### PR DESCRIPTION
### Summary
Adding the option to have Parquet index, instead of Avro btree. This is for batch-only use cases, where fetches are rare or not used at all. In such cases, in large scale, Avro index performance is (or at least should be) inferior to Parquet especially when filtering or projecting columns. 

In this implementation the index type (avrobtree/parquet) is stored in the index table props, and `fetch` throws UnsupportedException under parquet index. 