### PR TITLE
Fixing SparkAvroIndexer bug

### DIFF
--- a/dione-hadoop/src/main/scala/com/paypal/dione/avro/utils/GenericRecordMap.scala
+++ b/dione-hadoop/src/main/scala/com/paypal/dione/avro/utils/GenericRecordMap.scala
@@ -5,16 +5,29 @@ import org.apache.avro.util.Utf8
 
 import scala.collection.JavaConversions._
 
-case class GenericRecordMap(gr: GenericRecord) extends Map[String, AnyRef] {
+/**
+ * A simple wrapper class for returning a Map object instead of GenericRecord
+ */
+case class GenericRecordMap(gr: GenericRecord, projectedFields: Option[Seq[String]] = None) extends Map[String, AnyRef] {
   override def +[B1 >: AnyRef](kv: (String, B1)): Map[String, B1] = ???
 
-  override def get(key: String): Option[AnyRef] = gr.get(key) match {
-    case s: Utf8 => Some(s.toString)
-    case other => Option(other)
+  lazy private val projectedFieldsSet = projectedFields.map(_.toSet)
+
+  override def get(key: String): Option[AnyRef] = {
+    if (projectedFields.isEmpty || projectedFieldsSet.get.contains(key)) {
+      gr.get(key) match {
+        case s: Utf8 => Some(s.toString)
+        case other => Option(other)
+      }
+    } else None
   }
 
-  override def iterator: Iterator[(String, AnyRef)] =
-    gr.getSchema.getFields.toIterator.map(f => f.name() -> gr.get(f.name()))
+  override def iterator: Iterator[(String, AnyRef)] = {
+    if (projectedFields.nonEmpty)
+      projectedFields.get.toIterator.map(fname => fname -> gr.get(fname))
+    else
+      gr.getSchema.getFields.toIterator.map(f => f.name() -> gr.get(f.name()))
+  }
 
   override def -(key: String): Map[String, AnyRef] = ???
 }

--- a/dione-hadoop/src/main/scala/com/paypal/dione/avro/utils/GenericRecordMap.scala
+++ b/dione-hadoop/src/main/scala/com/paypal/dione/avro/utils/GenericRecordMap.scala
@@ -1,12 +1,17 @@
 package com.paypal.dione.avro.utils
 
 import org.apache.avro.generic.GenericRecord
+import org.apache.avro.util.Utf8
+
 import scala.collection.JavaConversions._
 
 case class GenericRecordMap(gr: GenericRecord) extends Map[String, AnyRef] {
   override def +[B1 >: AnyRef](kv: (String, B1)): Map[String, B1] = ???
 
-  override def get(key: String): Option[AnyRef] = Option(gr.get(key))
+  override def get(key: String): Option[AnyRef] = gr.get(key) match {
+    case s: Utf8 => Some(s.toString)
+    case other => Option(other)
+  }
 
   override def iterator: Iterator[(String, AnyRef)] =
     gr.getSchema.getFields.toIterator.map(f => f.name() -> gr.get(f.name()))

--- a/dione-spark/src/main/scala/com/paypal/dione/spark/index/IndexManager.scala
+++ b/dione-spark/src/main/scala/com/paypal/dione/spark/index/IndexManager.scala
@@ -199,7 +199,7 @@ case class IndexManager(@transient val spark: SparkSession, sparkIndexer: SparkI
     val dataTable = spark.table(dataTableName)
 
     fields
-      .map(keys ++ moreFields ++ _)
+      .map(keys ++ _)
       .map(cols => dataTable.select(cols.map(col): _*).schema)
       .getOrElse(getAllDataFields())
   }

--- a/dione-spark/src/main/scala/com/paypal/dione/spark/index/avro/AvroSparkIndexer.scala
+++ b/dione-spark/src/main/scala/com/paypal/dione/spark/index/avro/AvroSparkIndexer.scala
@@ -44,6 +44,6 @@ case class AvroSparkIndexer(@transient spark: SparkSession) extends SparkIndexer
   }
 
   def convertMap(gr: GenericRecord): Map[String, Any] =
-    GenericRecordMap(gr)
+    GenericRecordMap(gr, Some(fieldsSchema.fieldNames))
 
 }

--- a/dione-spark/src/test/scala/com/paypal/dione/spark/index/TestIndexManagerBase.scala
+++ b/dione-spark/src/test/scala/com/paypal/dione/spark/index/TestIndexManagerBase.scala
@@ -111,7 +111,7 @@ abstract class TestIndexManagerBase() extends SparkCleanTestDB {
     val indexManager = IndexManager.load(indexSpec.indexTableName)(spark)
     testSamples.foreach(sample => {
       val vars = indexManager.fetch(Seq(sample.key), Seq("dt" -> samplePartition))
-      Assertions.assertEquals(sample.varValue, vars.get("var1").toString)
+      Assertions.assertEquals(sample.varValue, vars.get("var1"))
       Assertions.assertEquals("List((id_col,msg_100), (meta_field,meta_100), (var1,var_a_100), (var2,100))",
         vars.get.toList.sortBy(_._1).toString)
     })
@@ -122,9 +122,10 @@ abstract class TestIndexManagerBase() extends SparkCleanTestDB {
   def testFetch(): Unit = {
     val indexManager = IndexManager.load(indexSpec.indexTableName)(spark)
     testSamples.foreach(sample => {
-      val vars = indexManager.fetch(Seq(sample.key), Seq("dt" -> samplePartition), Some(Seq("var2")))
-      Assertions.assertEquals(sample.varValue, vars.get("var1").toString)
-      Assertions.assertEquals("List((id_col,msg_100), (meta_field,meta_100), (var2,100))",
+      val vars = indexManager.fetch(Seq(sample.key), Seq("dt" -> samplePartition), Some(Seq("var1")))
+      Assertions.assertEquals(sample.varValue, vars.get("var1"))
+      Assertions.assertFalse(vars.get.contains("var2"))
+      Assertions.assertEquals("List((id_col,msg_100), (var1,var_a_100))",
         vars.get.toList.sortBy(_._1).toString)
     })
   }

--- a/dione-spark/src/test/scala/com/paypal/dione/spark/index/TestIndexManagerBase.scala
+++ b/dione-spark/src/test/scala/com/paypal/dione/spark/index/TestIndexManagerBase.scala
@@ -101,13 +101,13 @@ abstract class TestIndexManagerBase() extends SparkCleanTestDB {
       val hdfsIndexer = indexManager.sparkIndexer.initHdfsIndexer(new Path(gr.get(FILE_NAME_COLUMN).toString), fs.getConf, payloadSchema)
       val tData = hdfsIndexer.fetch(HdfsIndexerMetadata(gr))
       val grData = indexManager.sparkIndexer.convertMap(tData)
-      Assertions.assertEquals(Some(sample.varValue), grData.get("var1").map(_.toString))
+      Assertions.assertEquals(Some(sample.varValue), grData.get("var1"))
     })
   }
 
   @Order(6)
   @Test
-  def testFetch(): Unit = {
+  def testFetchAll(): Unit = {
     val indexManager = IndexManager.load(indexSpec.indexTableName)(spark)
     testSamples.foreach(sample => {
       val vars = indexManager.fetch(Seq(sample.key), Seq("dt" -> samplePartition))
@@ -117,4 +117,15 @@ abstract class TestIndexManagerBase() extends SparkCleanTestDB {
     })
   }
 
+  @Order(7)
+  @Test
+  def testFetch(): Unit = {
+    val indexManager = IndexManager.load(indexSpec.indexTableName)(spark)
+    testSamples.foreach(sample => {
+      val vars = indexManager.fetch(Seq(sample.key), Seq("dt" -> samplePartition), Some(Seq("var2")))
+      Assertions.assertEquals(sample.varValue, vars.get("var1").toString)
+      Assertions.assertEquals("List((id_col,msg_100), (meta_field,meta_100), (var2,100))",
+        vars.get.toList.sortBy(_._1).toString)
+    })
+  }
 }


### PR DESCRIPTION
# Summary
SparkAvroIndexer's fetch returns all fields and not just the requested ones.