### PR TITLE
Fix index reader performance bug

### DIFF
--- a/dione-spark/src/main/scala/com/paypal/dione/spark/index/IndexReader.scala
+++ b/dione-spark/src/main/scala/com/paypal/dione/spark/index/IndexReader.scala
@@ -199,7 +199,7 @@ object IndexReader {
     val partitions = math.max(shufflePartitions / repartitionRatio, 1)
 
     val reducedPartitionsDF =
-      keysDF.repartition(partitions, hash(col(FILE_NAME_COLUMN))).sortWithinPartitions(FILE_NAME_COLUMN, OFFSET_COLUMN)
+      keysDF.repartition(partitions, hash(col(FILE_NAME_COLUMN))).sortWithinPartitions(FILE_NAME_COLUMN, OFFSET_COLUMN, SUB_OFFSET_COLUMN)
 
     // now inside every partition we split the rows to chunks of X bytes.
     // the size of each row is predicted by `data_size` column which was


### PR DESCRIPTION
## Summary
Missing column in sorting, only effects performance, not logic/output.
Relying on existing tests.
