### PR TITLE
Fixing duplicated load requests bug

### DIFF
--- a/dione-spark/src/main/scala/com/paypal/dione/spark/index/IndexReader.scala
+++ b/dione-spark/src/main/scala/com/paypal/dione/spark/index/IndexReader.scala
@@ -29,6 +29,7 @@ case class IndexReader(@transient spark: SparkSession, sparkIndexer: SparkIndexe
   @transient private var currentFile: String = _
   @transient private var lastOffset = 0L
   @transient private var lastSubOffset = 0
+  @transient private var lastRow: Seq[Any] = _
 
   val reporter: StatsReporter = IndexReader.getReporter(spark)
 
@@ -96,6 +97,10 @@ case class IndexReader(@transient spark: SparkSession, sparkIndexer: SparkIndexe
     val size = indexRow.getAs[Int](SIZE_COLUMN)
     validateOrder(offset, subOffset, file)
 
+    // short-circuit the case when there is more than one read of the same entry
+    if (lastOffset == offset && lastSubOffset == subOffset)
+      return lastRow
+
     reporter.startRecordRead()
     if (offset != lastOffset) {
       logger.debug("seeking to offset {}", offset)
@@ -113,7 +118,8 @@ case class IndexReader(@transient spark: SparkSession, sparkIndexer: SparkIndexe
     val payload = hdfsIndexer.next()
     lastSubOffset = subOffset
     reporter.endRecordRead(size)
-    sparkIndexer.convert(payload)
+    lastRow = sparkIndexer.convert(payload)
+    lastRow
   }
 
   private def partitionDone(): Unit = {

--- a/dione-spark/src/test/scala/com/paypal/dione/spark/index/TestIndexManagerBase.scala
+++ b/dione-spark/src/test/scala/com/paypal/dione/spark/index/TestIndexManagerBase.scala
@@ -94,8 +94,7 @@ abstract class TestIndexManagerBase() extends SparkCleanTestDB {
       .withColumn("num", expr("explode(array(1,2,3))"))
     val payloadDF = indexManager.loadByIndex(queryDF, Some(Seq("var1")))
 
-    payloadDF.show()
-
+    Assertions.assertEquals(testSamples.size * 3, payloadDF.select("id_col").count)
     Assertions.assertEquals(testSamples.size, payloadDF.select("id_col").distinct().count)
   }
 

--- a/dione-spark/src/test/scala/com/paypal/dione/spark/index/TestIndexManagerBase.scala
+++ b/dione-spark/src/test/scala/com/paypal/dione/spark/index/TestIndexManagerBase.scala
@@ -6,7 +6,7 @@ import com.paypal.dione.hdfs.index.HdfsIndexerMetadata
 import com.paypal.dione.kvstorage.hadoop.avro.AvroHashBtreeStorageFolderReader
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.functions.{col, expr}
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
 import org.junit.jupiter.api.TestInstance.Lifecycle
 import org.junit.jupiter.api._
@@ -82,6 +82,21 @@ abstract class TestIndexManagerBase() extends SparkCleanTestDB {
           .select((indexSpec.keys ++ indexSpec.moreFields ++ Seq("var1")).map(col):_*)
           .collect().toList.toString)
     })
+  }
+
+  @Test
+  @Order(4)
+  def testLoadByIndexDuplicateRequests(): Unit = {
+    val indexManager = IndexManager.load(indexSpec.indexTableName)(spark)
+    val sampleDF = spark.createDataFrame(testSamples.map(x=>(x.key, x.size))).toDF("id_col", "some_size")
+    // duplicate the row a few times
+    val queryDF = indexManager.getIndex().join(sampleDF, "id_col")
+      .withColumn("num", expr("explode(array(1,2,3))"))
+    val payloadDF = indexManager.loadByIndex(queryDF, Some(Seq("var1")))
+
+    payloadDF.show()
+
+    Assertions.assertEquals(testSamples.size, payloadDF.select("id_col").distinct().count)
   }
 
   @Order(5)

--- a/pom.xml
+++ b/pom.xml
@@ -261,6 +261,19 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.2.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
                 <version>1.6.7</version>
@@ -279,19 +292,6 @@
             <id>publish</id>
             <build>
                 <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-source-plugin</artifactId>
-                        <version>2.2.1</version>
-                        <executions>
-                            <execution>
-                                <id>attach-sources</id>
-                                <goals>
-                                    <goal>jar-no-fork</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>


### PR DESCRIPTION
## Summary

When a user requests to load from the index duplicated rows of the same filename, offset and sub-offset we have a bug that we continue to iterate on the data and return incorrect results.

## Detailed Description
when we iterate on the load "requests" we assume they are not duplicated and always advance the data iterator.
This fix adds a short-circuit for this case.

## How was it tested?
added a unitest
 