### PR TITLE
Bugfix to support non string partitions

### DIFF
--- a/.github/workflows/dev-pr-main.workflow.yml
+++ b/.github/workflows/dev-pr-main.workflow.yml
@@ -70,6 +70,7 @@ jobs:
           find .
           export PYTHONPATH=`echo dione-spark/target/dione-spark-*-SNAPSHOT.jar`
           python -V
+          pip install pypandoc==1.7.5
           pip install pytest pyspark==2.3.4
           echo ohad
           AVRO_JAR=$(find $(dirname `which python`)/../ -name "avro-1*.jar")

--- a/dione-hadoop/pom.xml
+++ b/dione-hadoop/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>dione-parent</artifactId>
         <groupId>com.paypal.dione</groupId>
-        <version>0.5.1</version>
+        <version>0.5.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/dione-spark/pom.xml
+++ b/dione-spark/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>dione-parent</artifactId>
         <groupId>com.paypal.dione</groupId>
-        <version>0.5.1</version>
+        <version>0.5.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -17,12 +17,12 @@
         <dependency>
             <groupId>com.paypal.dione</groupId>
             <artifactId>dione-hadoop</artifactId>
-            <version>0.5.1</version>
+            <version>0.5.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.paypal.dione</groupId>
             <artifactId>dione-hadoop</artifactId>
-            <version>0.5.1</version>
+            <version>0.5.2-SNAPSHOT</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>

--- a/dione-spark/src/main/scala/com/paypal/dione/spark/index/IndexManagerUtils.scala
+++ b/dione-spark/src/main/scala/com/paypal/dione/spark/index/IndexManagerUtils.scala
@@ -208,8 +208,8 @@ object IndexManagerUtils {
   def getTablePartitions(keysTableName: String, valuesDF: DataFrame, spark: SparkSession): Seq[Seq[(String, String)]] = {
     val partitionKeys = spark.catalog.listColumns(keysTableName).filter(_.isPartition).collect().map(_.name)
     val partitionValues = valuesDF.selectExpr(partitionKeys:_*).distinct()
-    val valuesMap = partitionValues.collect().map(_.getValuesMap[String](partitionKeys)).distinct
-    valuesMap.map(_.toSeq).toSeq
+    val valuesMap = partitionValues.collect().map(_.getValuesMap[Any](partitionKeys)).distinct
+    valuesMap.map(_.mapValues(_.toString).toSeq).toSeq
   }
 
   def toSafeDataFrame(df: DataFrame): DataFrame = {

--- a/dione-spark/src/test/python/conftest.py
+++ b/dione-spark/src/test/python/conftest.py
@@ -20,8 +20,8 @@ def spark_session():
     remove_folder('spark-warehouse')
 
     dione_jars = [
-        "dione-hadoop/target/dione-hadoop-0.5.1-SNAPSHOT.jar",
-        "dione-spark/target/dione-spark-0.5.1-SNAPSHOT.jar"
+        "dione-hadoop/target/dione-hadoop-0.5.2-SNAPSHOT.jar",
+        "dione-spark/target/dione-spark-0.5.2-SNAPSHOT.jar"
     ]
 
     spark_jars = [

--- a/dione-spark/src/test/scala/com/paypal/dione/spark/index/TestIndexManagerBase.scala
+++ b/dione-spark/src/test/scala/com/paypal/dione/spark/index/TestIndexManagerBase.scala
@@ -20,12 +20,12 @@ abstract class TestIndexManagerBase() extends SparkCleanTestDB {
 
   def indexSpec: IndexSpec
 
-  val samplePartition: String = "2021-02-03"
+  val samplePartition: String
 
   case class SampleTest(key: String, moreFields: Seq[String], varValue: String, offset: Long, subOffset: Int, size: Int)
   val testSamples: Seq[SampleTest]
 
-  def initDataTable(fieldsSchema: String, partitionFieldSchema: String): Unit
+  def initDataTable(fieldsSchema: String, partitionFieldName: String): Unit
 
   @Test
   @Order(0)
@@ -34,14 +34,14 @@ abstract class TestIndexManagerBase() extends SparkCleanTestDB {
     import spark.implicits._
 
     initDataTable("id_col string, var1 string, var2 int, meta_field string",
-      "dt string")
+      "dt")
 
     (1 to 300).map(i => ("msg_" + i, "var_a_" + i, i, "meta_"+i))
       .toDF("id_col", "var1", "var2", "meta_field")
       .repartition(3)
       .createOrReplaceTempView("t")
 
-    spark.sql(s"insert overwrite table ${indexSpec.dataTableName} partition (dt='2021-02-03') select * from t")
+    spark.sql(s"insert overwrite table ${indexSpec.dataTableName} partition (dt=${samplePartition}) select * from t")
   }
 
 
@@ -101,7 +101,7 @@ abstract class TestIndexManagerBase() extends SparkCleanTestDB {
   @Order(5)
   @Test
   def testNoSparkGetAndFetch(): Unit = {
-    val showPartition = spark.sql(s"desc formatted ${indexSpec.indexTableName} partition (dt='"+samplePartition+"')").collect()
+    val showPartition = spark.sql(s"desc formatted ${indexSpec.indexTableName} partition (dt="+samplePartition+")").collect()
     val specificIndexFolder = showPartition.find(row => row.getString(0).contains("Location")).get.getString(1)
     val avroHashBtreeFolderReader = AvroHashBtreeStorageFolderReader(specificIndexFolder)
 
@@ -124,7 +124,9 @@ abstract class TestIndexManagerBase() extends SparkCleanTestDB {
   def testFetch(): Unit = {
     val indexManager = IndexManager.load(indexSpec.indexTableName)(spark)
     testSamples.foreach(sample => {
-      val vars = indexManager.fetch(Seq(sample.key), Seq("dt" -> samplePartition))
+      // to support also non string partition types we added "'" to the partition value (not the cleanest way)
+      val samplePartitionClean = samplePartition.replace("'", "")
+      val vars = indexManager.fetch(Seq(sample.key), Seq("dt" -> samplePartitionClean))
       Assertions.assertEquals(sample.varValue, vars.get("var1").toString)
       Assertions.assertEquals("List((id_col,msg_100), (meta_field,meta_100), (var1,var_a_100), (var2,100))",
         vars.get.toList.sortBy(_._1).toString)

--- a/dione-spark/src/test/scala/com/paypal/dione/spark/index/avro/TestAvroIndexManagerBase.scala
+++ b/dione-spark/src/test/scala/com/paypal/dione/spark/index/avro/TestAvroIndexManagerBase.scala
@@ -10,9 +10,11 @@ class TestAvroIndexManagerBase extends TestIndexManagerBase {
 
   lazy val indexSpec: IndexSpec = IndexSpec("avro_data_tbl", "avro_data_tbl_idx", Seq("id_col"))
 
-  def initDataTable(fieldsSchema: String, partitionFieldSchema: String): Unit = {
-    spark.sql(s"create table ${indexSpec.dataTableName} ($fieldsSchema) partitioned by ($partitionFieldSchema) stored as avro")
+  def initDataTable(fieldsSchema: String, partitionFieldName: String): Unit = {
+    spark.sql(s"create table ${indexSpec.dataTableName} ($fieldsSchema) partitioned by ($partitionFieldName long) stored as avro")
   }
 
   val testSamples = Seq(SampleTest("msg_100", Nil, "var_a_100", 349, 22, 31))
+
+  override val samplePartition: String = "20210203"
 }

--- a/dione-spark/src/test/scala/com/paypal/dione/spark/index/orc/TestOrcIndexManagerBase.scala
+++ b/dione-spark/src/test/scala/com/paypal/dione/spark/index/orc/TestOrcIndexManagerBase.scala
@@ -10,9 +10,11 @@ class TestOrcIndexManagerBase extends TestIndexManagerBase {
 
   lazy val indexSpec: IndexSpec = IndexSpec("orc_data_tbl", "orc_data_tbl_idx", Seq("id_col"))
 
-  def initDataTable(fieldsSchema: String, partitionFieldSchema: String): Unit = {
-    spark.sql(s"create table ${indexSpec.dataTableName} ($fieldsSchema) partitioned by ($partitionFieldSchema) stored as orc")
+  def initDataTable(fieldsSchema: String, partitionFieldName: String): Unit = {
+    spark.sql(s"create table ${indexSpec.dataTableName} ($fieldsSchema) partitioned by ($partitionFieldName string) stored as orc")
   }
 
   val testSamples = Seq(SampleTest("msg_100", Nil, "var_a_100", 22, 0, -1))
+
+  override val samplePartition: String = "'2021-02-03'"
 }

--- a/dione-spark/src/test/scala/com/paypal/dione/spark/index/parquet/TestParquetIndexManagerBase.scala
+++ b/dione-spark/src/test/scala/com/paypal/dione/spark/index/parquet/TestParquetIndexManagerBase.scala
@@ -10,13 +10,15 @@ class TestParquetIndexManagerBase extends TestIndexManagerBase {
 
   lazy val indexSpec: IndexSpec = IndexSpec("parquet_data_tbl", "parquet_data_tbl_idx", Seq("id_col"), Seq("meta_field"))
 
-  def initDataTable(fieldsSchema: String, partitionFieldSchema: String): Unit = {
+  def initDataTable(fieldsSchema: String, partitionFieldName: String): Unit = {
     val sc = spark.sparkContext
     sc.hadoopConfiguration.setInt("parquet.block.size", 100)
 
-    spark.sql(s"create table ${indexSpec.dataTableName} ($fieldsSchema) partitioned by ($partitionFieldSchema) stored as parquet")
+    spark.sql(s"create table ${indexSpec.dataTableName} ($fieldsSchema) partitioned by ($partitionFieldName string) stored as parquet")
 
   }
 
   val testSamples = Seq(SampleTest("msg_100", Seq("meta_100"), "var_a_100", 0, 22, -1))
+
+  override val samplePartition: String = "'2021-02-03'"
 }

--- a/dione-spark/src/test/scala/com/paypal/dione/spark/index/sequence/TestSequenceFileIndexManagerBase.scala
+++ b/dione-spark/src/test/scala/com/paypal/dione/spark/index/sequence/TestSequenceFileIndexManagerBase.scala
@@ -10,9 +10,9 @@ class TestSequenceFileIndexManagerBase extends TestIndexManagerBase {
 
   lazy val indexSpec: IndexSpec = IndexSpec("seq_file_data_tbl", "seq_file_data_tbl_idx", Seq("id_col"), Seq("meta_field"))
 
-  def initDataTable(fieldsSchema: String, partitionFieldSchema: String): Unit = {
+  def initDataTable(fieldsSchema: String, partitionFieldName: String): Unit = {
     spark.sql(s"create table ${indexSpec.dataTableName} ($fieldsSchema)" +
-      s" partitioned by ($partitionFieldSchema)" +
+      s" partitioned by ($partitionFieldName string)" +
       s""" ROW FORMAT DELIMITED
         FIELDS TERMINATED BY '\u0010'
         STORED AS INPUTFORMAT
@@ -23,5 +23,6 @@ class TestSequenceFileIndexManagerBase extends TestIndexManagerBase {
   }
 
   val testSamples = Seq(SampleTest("msg_100", Seq("meta_100"), "var_a_100", 985, 0, 35))
-  
+
+  override val samplePartition: String = "'2021-02-03'"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <description>an HDFS indexing library</description>
     <url>https://github.com/paypal/dione</url>
 
-    <version>0.5.1</version>
+    <version>0.5.2-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 


### PR DESCRIPTION
## Summary
We currently fail if the data partition is non string type (for example bigint/long).

## Detailed Description
this is a sort-of workaround to convert the partition to string. it is not the best solution, but I believe it is good enough for our use as for example in Hive partition values are by default converted to strings as they are part of the folder name.

## How was it tested?
changed the unit tests and also saw it resolves the "real" use case.
 