### PR TITLE
Bugfix to support non string partitions

### DIFF
--- a/.github/workflows/pr.workflow.yml
+++ b/.github/workflows/pr.workflow.yml
@@ -70,5 +70,6 @@ jobs:
           find .
           export PYTHONPATH=`echo dione-spark/target/dione-spark-*-SNAPSHOT.jar`
           python -V
+          pip install pypandoc==1.7.5
           pip install pytest pyspark==2.4.8
           pytest -v

--- a/dione-spark/src/main/scala/com/paypal/dione/spark/index/IndexManagerUtils.scala
+++ b/dione-spark/src/main/scala/com/paypal/dione/spark/index/IndexManagerUtils.scala
@@ -207,8 +207,8 @@ object IndexManagerUtils {
   def getTablePartitions(keysTableName: String, valuesDF: DataFrame, spark: SparkSession): Seq[Seq[(String, String)]] = {
     val partitionKeys = spark.catalog.listColumns(keysTableName).filter(_.isPartition).collect().map(_.name)
     val partitionValues = valuesDF.selectExpr(partitionKeys:_*).distinct()
-    val valuesMap = partitionValues.collect().map(_.getValuesMap[String](partitionKeys)).distinct
-    valuesMap.map(_.toSeq).toSeq
+    val valuesMap = partitionValues.collect().map(_.getValuesMap[Any](partitionKeys)).distinct
+    valuesMap.map(_.mapValues(_.toString).toSeq).toSeq
   }
 
   def toSafeDataFrame(df: DataFrame): DataFrame = {

--- a/dione-spark/src/test/scala/com/paypal/dione/spark/index/avro/TestAvroIndexManagerBase.scala
+++ b/dione-spark/src/test/scala/com/paypal/dione/spark/index/avro/TestAvroIndexManagerBase.scala
@@ -10,9 +10,11 @@ class TestAvroIndexManagerBase extends TestIndexManagerBase {
 
   lazy val indexSpec: IndexSpec = IndexSpec("avro_data_tbl", "avro_data_tbl_idx", Seq("id_col"))
 
-  def initDataTable(fieldsSchema: String, partitionFieldSchema: String): Unit = {
-    spark.sql(s"create table ${indexSpec.dataTableName} ($fieldsSchema) partitioned by ($partitionFieldSchema) stored as avro")
+  def initDataTable(fieldsSchema: String, partitionFieldName: String): Unit = {
+    spark.sql(s"create table ${indexSpec.dataTableName} ($fieldsSchema) partitioned by ($partitionFieldName long) stored as avro")
   }
 
   val testSamples = Seq(SampleTest("msg_100", Nil, "var_a_100", 349, 22, 31))
+
+  override val samplePartition: String = "20210203"
 }

--- a/dione-spark/src/test/scala/com/paypal/dione/spark/index/orc/TestOrcIndexManagerBase.scala
+++ b/dione-spark/src/test/scala/com/paypal/dione/spark/index/orc/TestOrcIndexManagerBase.scala
@@ -10,9 +10,11 @@ class TestOrcIndexManagerBase extends TestIndexManagerBase {
 
   lazy val indexSpec: IndexSpec = IndexSpec("orc_data_tbl", "orc_data_tbl_idx", Seq("id_col"))
 
-  def initDataTable(fieldsSchema: String, partitionFieldSchema: String): Unit = {
-    spark.sql(s"create table ${indexSpec.dataTableName} ($fieldsSchema) partitioned by ($partitionFieldSchema) stored as orc")
+  def initDataTable(fieldsSchema: String, partitionFieldName: String): Unit = {
+    spark.sql(s"create table ${indexSpec.dataTableName} ($fieldsSchema) partitioned by ($partitionFieldName string) stored as orc")
   }
 
   val testSamples = Seq(SampleTest("msg_100", Nil, "var_a_100", 22, 0, -1))
+
+  override val samplePartition: String = "'2021-02-03'"
 }

--- a/dione-spark/src/test/scala/com/paypal/dione/spark/index/parquet/TestParquetIndexManagerBase.scala
+++ b/dione-spark/src/test/scala/com/paypal/dione/spark/index/parquet/TestParquetIndexManagerBase.scala
@@ -10,13 +10,15 @@ class TestParquetIndexManagerBase extends TestIndexManagerBase {
 
   lazy val indexSpec: IndexSpec = IndexSpec("parquet_data_tbl", "parquet_data_tbl_idx", Seq("id_col"), Seq("meta_field"))
 
-  def initDataTable(fieldsSchema: String, partitionFieldSchema: String): Unit = {
+  def initDataTable(fieldsSchema: String, partitionFieldName: String): Unit = {
     val sc = spark.sparkContext
     sc.hadoopConfiguration.setInt("parquet.block.size", 100)
 
-    spark.sql(s"create table ${indexSpec.dataTableName} ($fieldsSchema) partitioned by ($partitionFieldSchema) stored as parquet")
+    spark.sql(s"create table ${indexSpec.dataTableName} ($fieldsSchema) partitioned by ($partitionFieldName string) stored as parquet")
 
   }
 
   val testSamples = Seq(SampleTest("msg_100", Seq("meta_100"), "var_a_100", 0, 22, -1))
+
+  override val samplePartition: String = "'2021-02-03'"
 }

--- a/dione-spark/src/test/scala/com/paypal/dione/spark/index/sequence/TestSequenceFileIndexManagerBase.scala
+++ b/dione-spark/src/test/scala/com/paypal/dione/spark/index/sequence/TestSequenceFileIndexManagerBase.scala
@@ -10,9 +10,9 @@ class TestSequenceFileIndexManagerBase extends TestIndexManagerBase {
 
   lazy val indexSpec: IndexSpec = IndexSpec("seq_file_data_tbl", "seq_file_data_tbl_idx", Seq("id_col"), Seq("meta_field"))
 
-  def initDataTable(fieldsSchema: String, partitionFieldSchema: String): Unit = {
+  def initDataTable(fieldsSchema: String, partitionFieldName: String): Unit = {
     spark.sql(s"create table ${indexSpec.dataTableName} ($fieldsSchema)" +
-      s" partitioned by ($partitionFieldSchema)" +
+      s" partitioned by ($partitionFieldName string)" +
       s""" ROW FORMAT DELIMITED
         FIELDS TERMINATED BY '\u0010'
         STORED AS INPUTFORMAT
@@ -23,5 +23,6 @@ class TestSequenceFileIndexManagerBase extends TestIndexManagerBase {
   }
 
   val testSamples = Seq(SampleTest("msg_100", Seq("meta_100"), "var_a_100", 985, 0, 35))
-  
+
+  override val samplePartition: String = "'2021-02-03'"
 }


### PR DESCRIPTION
## Summary

We currently fail if the data partition is non string type (for example bigint/long). This is a duplicate of PR #62 for the _main_ branch.

## Detailed Description
this is a sort-of workaround to convert the partition to string. it is not the best solution, but I believe it is good enough for our use as for example in Hive partition values are by default converted to strings as they are part of the folder name.

## How was it tested?
Changed the unit tests and also saw it resolves the "real" use case.  (on the _release/0.5_ branch)