### PR TITLE
fix can't skip row group issue when using ParquetIndexer.

### DIFF
--- a/dione-hadoop/src/main/java/com/paypal/dione/hdfs/index/parquet/MyInternalParquetRecordReader.java
+++ b/dione-hadoop/src/main/java/com/paypal/dione/hdfs/index/parquet/MyInternalParquetRecordReader.java
@@ -36,10 +36,8 @@ import org.apache.parquet.io.api.RecordMaterializer.RecordMaterializationExcepti
 import org.apache.parquet.schema.MessageType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.util.*;
-
 import static java.lang.String.format;
 import static org.apache.parquet.Preconditions.checkNotNull;
 import static org.apache.parquet.hadoop.ParquetInputFormat.RECORD_FILTERING_ENABLED;
@@ -50,7 +48,7 @@ import static org.apache.parquet.hadoop.ParquetInputFormat.STRICT_TYPE_CHECKING;
  * currentInBlock, etc.
  */
 
-class MyInternalParquetRecordReader<T> {
+public class MyInternalParquetRecordReader<T> {
   private static final Logger LOG = LoggerFactory.getLogger(MyInternalParquetRecordReader.class);
 
   private ColumnIOFactory columnIOFactory = null;
@@ -66,6 +64,7 @@ class MyInternalParquetRecordReader<T> {
 
   private T currentValue;
   private long total;
+  private long rowGroupSize;
   private long current = 0;
   private int currentBlock = -1;
   private int currentInBlock = -1;
@@ -156,7 +155,13 @@ class MyInternalParquetRecordReader<T> {
   }
 
   public boolean skipRowGroup() {
-    LOG.info("skipping block {}", currentBlock);
+    if(currentBlock + 1 >= rowGroupSize) {
+      LOG.info("Already reached the last row group {}, ignored.", currentBlock);
+      current = totalCountLoadedSoFar;
+      return true;
+    }
+    LOG.info("skipping block {}", ++currentBlock);
+    current = totalCountLoadedSoFar;
     return reader.skipNextRowGroup();
   }
 
@@ -185,11 +190,12 @@ class MyInternalParquetRecordReader<T> {
         configuration, fileMetadata, fileSchema, readContext);
     this.strictTypeChecking = configuration.getBoolean(STRICT_TYPE_CHECKING, true);
     this.total = reader.getRecordCount();
+    this.rowGroupSize = reader.getRowGroups().size();
     this.unmaterializableRecordCounter = new UnmaterializableRecordCounter(configuration, total);
     this.filterRecords = configuration.getBoolean(
         RECORD_FILTERING_ENABLED, false);
     reader.setRequestedSchema(requestedSchema);
-    LOG.info("RecordReader initialized will read a total of {} records.", total);
+    LOG.info("RecordReader initialized will read a total of {} records with {} row groups.", total, rowGroupSize);
   }
 
   public boolean nextKeyValue() throws IOException {
@@ -228,7 +234,7 @@ class MyInternalParquetRecordReader<T> {
 
         recordFound = true;
 
-        LOG.debug("read value: {}", currentValue);
+        LOG.debug("read value[offset: {}, sub_offset {}, current {}]: {}", currentBlock, currentInBlock, current, currentValue.toString().substring(0, 200));
       } catch (RuntimeException e) {
         throw new ParquetDecodingException(format("Can not read value at %d in block %d in file %s", current, currentBlock, reader.getPath()), e);
       }

--- a/dione-hadoop/src/main/java/com/paypal/dione/hdfs/index/parquet/MyInternalParquetRecordReader.java
+++ b/dione-hadoop/src/main/java/com/paypal/dione/hdfs/index/parquet/MyInternalParquetRecordReader.java
@@ -234,7 +234,7 @@ public class MyInternalParquetRecordReader<T> {
 
         recordFound = true;
 
-        LOG.debug("read value[offset: {}, sub_offset {}, current {}]: {}", currentBlock, currentInBlock, current, currentValue.toString().substring(0, 200));
+        LOG.debug("read value[offset: {}, sub_offset {}, current {}]: {}", currentBlock, currentInBlock, current, currentValue.toString());
       } catch (RuntimeException e) {
         throw new ParquetDecodingException(format("Can not read value at %d in block %d in file %s", current, currentBlock, reader.getPath()), e);
       }


### PR DESCRIPTION
## Summary
The method skipRowGroup in MyInternalParquetRecordReader not work and would return error records when querying.

resolves #PR/#Issue

don't forget:
- please state if it is not backward compatible **[backward compatible]**
- please add relevant docs to either the function description, or the relevant doc file 

## Detailed Description
explain the implementation, what is the problem? how did you solve it?

Problem:
The record reader of the row group won't  be changed after invoking skipRowGroup and make it a fake skip.
eg: 
Required location -> row group 9, #172 row
After run the skipRowGroup 8 times, the record reader is still belongs to row group 0 instead of row group 9.

Solution:
increase the currentBlock & move the current to end of the group, then checkRead will check it and initialize a new row group.

## How was it tested?
(unit test/integration test)
integration test in PayPal prod env.
 