### PR TITLE
Fix sync interval

### DIFF
--- a/.github/workflows/pr.workflow.yml
+++ b/.github/workflows/pr.workflow.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Maven build
         run:
-            mvn -B -V clean package
+            mvn -B -V clean package -DargLine="-Xmx4000m"
 
       - name: Upload jar file
         uses: actions/upload-artifact@v2

--- a/.github/workflows/pr.workflow.yml
+++ b/.github/workflows/pr.workflow.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Maven build
         run:
-            mvn -B -V clean package -DargLine="-Xmx4000m"
+            mvn -B -V clean package
 
       - name: Upload jar file
         uses: actions/upload-artifact@v2

--- a/dione-hadoop/src/main/java/com/paypal/dione/avro/hadoop/file/AvroBtreeFile.java
+++ b/dione-hadoop/src/main/java/com/paypal/dione/avro/hadoop/file/AvroBtreeFile.java
@@ -578,7 +578,7 @@ public class AvroBtreeFile {
 
             this.schema = schema;
             this.recordsBuffer = recordsBuffer;
-            this.memoryWriter = inMemoryWriter.setSyncInterval(Integer.MAX_VALUE);
+            this.memoryWriter = inMemoryWriter.setSyncInterval(1 << 30);
             this.headerPosition = inMemoryWriter.sync();
             this.options = options;
             syncs = new LinkedList<>();
@@ -627,7 +627,7 @@ public class AvroBtreeFile {
                         .setMeta(DATA_SIZE_KEY, dataSize) // put data size in metadata:
                         .setMeta(KEY_VALUE_HEADER_NAME, keyValueFields) // put data size in metadata:
                         .setCodec(options.getCodec())
-                        .setSyncInterval(Integer.MAX_VALUE)
+                        .setSyncInterval(1 << 30)
                         .create(schema, output);
 
                 // read blocks backwards, and append to the real file:

--- a/dione-hadoop/src/main/java/com/paypal/dione/avro/hadoop/file/AvroBtreeFile.java
+++ b/dione-hadoop/src/main/java/com/paypal/dione/avro/hadoop/file/AvroBtreeFile.java
@@ -592,7 +592,6 @@ public class AvroBtreeFile {
             DatumWriter<GenericRecord> datumWriter = model.createDatumWriter(schema);
             DataFileWriter<GenericRecord> inMemoryWriter =
                     new DataFileWriter<>(datumWriter)
-                            .setSyncInterval(Integer.MAX_VALUE)
                             .setCodec(options.getCodec())
                             .create(schema, recordsBuffer);
             return inMemoryWriter;

--- a/dione-hadoop/src/main/java/com/paypal/dione/avro/hadoop/file/AvroBtreeFile.java
+++ b/dione-hadoop/src/main/java/com/paypal/dione/avro/hadoop/file/AvroBtreeFile.java
@@ -38,6 +38,7 @@ public class AvroBtreeFile {
     public static final String METADATA_COL_NAME = "metadata";
     public static final String KEY_VALUE_HEADER_NAME = "btree.spec.kv";
     private static final Logger logger = LoggerFactory.getLogger(AvroBtreeFile.class);
+    private static final int SYNC_INTERVAL = (1 << 20) * 10; // 10 MB
 
     // Schema of Long that can be null
     public static Schema metadataSchema = SchemaBuilder.unionOf().nullType().and().longType().endUnion();
@@ -578,7 +579,7 @@ public class AvroBtreeFile {
 
             this.schema = schema;
             this.recordsBuffer = recordsBuffer;
-            this.memoryWriter = inMemoryWriter.setSyncInterval(1 << 30);
+            this.memoryWriter = inMemoryWriter.setSyncInterval(SYNC_INTERVAL);
             this.headerPosition = inMemoryWriter.sync();
             this.options = options;
             syncs = new LinkedList<>();
@@ -627,7 +628,7 @@ public class AvroBtreeFile {
                         .setMeta(DATA_SIZE_KEY, dataSize) // put data size in metadata:
                         .setMeta(KEY_VALUE_HEADER_NAME, keyValueFields) // put data size in metadata:
                         .setCodec(options.getCodec())
-                        .setSyncInterval(1 << 30)
+                        .setSyncInterval(SYNC_INTERVAL)
                         .create(schema, output);
 
                 // read blocks backwards, and append to the real file:

--- a/dione-hadoop/src/main/java/com/paypal/dione/avro/hadoop/file/AvroBtreeFile.java
+++ b/dione-hadoop/src/main/java/com/paypal/dione/avro/hadoop/file/AvroBtreeFile.java
@@ -578,7 +578,7 @@ public class AvroBtreeFile {
 
             this.schema = schema;
             this.recordsBuffer = recordsBuffer;
-            this.memoryWriter = inMemoryWriter.setSyncInterval(1 << 20);
+            this.memoryWriter = inMemoryWriter.setSyncInterval(Integer.MAX_VALUE);
             this.headerPosition = inMemoryWriter.sync();
             this.options = options;
             syncs = new LinkedList<>();
@@ -592,7 +592,7 @@ public class AvroBtreeFile {
             DatumWriter<GenericRecord> datumWriter = model.createDatumWriter(schema);
             DataFileWriter<GenericRecord> inMemoryWriter =
                     new DataFileWriter<>(datumWriter)
-                            .setSyncInterval(1 << 20)
+                            .setSyncInterval(Integer.MAX_VALUE)
                             .setCodec(options.getCodec())
                             .create(schema, recordsBuffer);
             return inMemoryWriter;
@@ -628,7 +628,7 @@ public class AvroBtreeFile {
                         .setMeta(DATA_SIZE_KEY, dataSize) // put data size in metadata:
                         .setMeta(KEY_VALUE_HEADER_NAME, keyValueFields) // put data size in metadata:
                         .setCodec(options.getCodec())
-                        .setSyncInterval(1 << 20)
+                        .setSyncInterval(Integer.MAX_VALUE)
                         .create(schema, output);
 
                 // read blocks backwards, and append to the real file:

--- a/dione-spark/src/main/scala/com/paypal/dione/spark/avro/btree/AvroBtreeOutputWriter.scala
+++ b/dione-spark/src/main/scala/com/paypal/dione/spark/avro/btree/AvroBtreeOutputWriter.scala
@@ -63,7 +63,7 @@ class AvroBtreeOutputWriter( path: String,
       .withInterval(jobOptions.interval)
       .withHeight(jobOptions.height)
       .withCodec(codecFactory)
-      .withAvroSyncInterval(jobOptions.syncInterval)
+      .withAvroSyncInterval(context.getConfiguration.getInt("btree.avro.syncInterval", 10 << 20))
       .withPath(new Path(path))
 
     new AvroBtreeFile.Writer(avroBtreeFileOptions)

--- a/dione-spark/src/main/scala/com/paypal/dione/spark/avro/btree/AvroBtreeOutputWriter.scala
+++ b/dione-spark/src/main/scala/com/paypal/dione/spark/avro/btree/AvroBtreeOutputWriter.scala
@@ -63,6 +63,7 @@ class AvroBtreeOutputWriter( path: String,
       .withInterval(jobOptions.interval)
       .withHeight(jobOptions.height)
       .withCodec(codecFactory)
+      .withAvroSyncInterval(jobOptions.syncInterval)
       .withPath(new Path(path))
 
     new AvroBtreeFile.Writer(avroBtreeFileOptions)

--- a/dione-spark/src/main/scala/com/paypal/dione/spark/avro/btree/WriterOptions.scala
+++ b/dione-spark/src/main/scala/com/paypal/dione/spark/avro/btree/WriterOptions.scala
@@ -1,12 +1,7 @@
 package com.paypal.dione.spark.avro.btree
 
-import java.io.{ByteArrayInputStream, DataInputStream}
-import java.util.Base64
-
 import org.apache.avro.file.CodecFactory
-import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
-import org.apache.spark.sql.SaveMode
 import org.apache.spark.sql.types.StructType
 
 import scala.util.Try
@@ -19,32 +14,30 @@ class AvroBtreeJobOptions(val schema: StructType,
                          ) extends Serializable {
   validate()
 
-  def hadoopConf = {
-    val conf = new Configuration()
-    conf.readFields(new DataInputStream(new ByteArrayInputStream(Base64.getDecoder.decode(map("__hadoop.conf")))))
-    conf
-  }
-
   def basePath: Path = new Path(map("path"))
-//  def stagingPath: Path = basePath.child(".staging")
+
+  //  def stagingPath: Path = basePath.child(".staging")
   def keyRecordName: String = map.getOrElse("avro.keyRecordName", "key")
+
   def valueRecordName: String = map.getOrElse("avro.valueRecordName", "value")
+
   def recordNamespace: String = map.getOrElse("avro.recordNamespace", "indexer")
+
   def compression: String = map.getOrElse("avro.compression", "deflate")
 
   def keyFields: Seq[String] = map("key.fields").split(",").map(_.trim)
+
   def valueFields: Seq[String] = map("value.fields").split(",").map(_.trim)
 
   def interval: Int = map.getOrElse("btree.interval", "1000").toInt
+
   def height: Int = map.getOrElse("btree.height", "4").toInt
-  def syncInterval: Int = map.getOrElse("btree.avro.syncInterval", (10 << 20).toString).toInt
 
   def cleanup: Boolean = map.get("cleanup").forall(_.toBoolean)
 
 
   private def validate() = {
     // required options:
-//    Seq("key.fields", "value.fields", "__hadoop.conf").foreach { key =>
     Seq("key.fields", "value.fields").foreach { key =>
       map.getOrElse(key, throw new IllegalArgumentException("missing option: " + key))
     }

--- a/dione-spark/src/main/scala/com/paypal/dione/spark/avro/btree/WriterOptions.scala
+++ b/dione-spark/src/main/scala/com/paypal/dione/spark/avro/btree/WriterOptions.scala
@@ -37,8 +37,9 @@ class AvroBtreeJobOptions(val schema: StructType,
 
   def interval: Int = map.getOrElse("btree.interval", "1000").toInt
   def height: Int = map.getOrElse("btree.height", "4").toInt
+  def syncInterval: Int = map.getOrElse("btree.avro.syncInterval", (10 << 20).toString).toInt
 
-  def cleanup = map.get("cleanup").forall(_.toBoolean)
+  def cleanup: Boolean = map.get("cleanup").forall(_.toBoolean)
 
 
   private def validate() = {


### PR DESCRIPTION
## Summary
Fixing issue #67. 

## Detailed Description
The default, hard-coded sync interval value was set to 1 MB, which we considered "large enough". The failed test has 100k rows which **probably** overflow from a single block and mess up the assumed blocks. Have to admit, I didn't deep dive into it  (It's been a while since I wrote this specific code) - so the root cause might be different.

Fixed by changing to 10MB instead. Note, we shouldn't overshoot the value to some max value (Avro allows up to 1G). This is because Avro file writer initializes a byte buffer of the same value, which is pretty expensive for 1G. In our case, mvn build goes OOM. 

This is more of a patch, we should let the user configure this externally.

## How was it tested?
Relying on @uzadude's test
 