### PR TITLE
Adding LRU Caching for sorted iterator

### DIFF
--- a/dione-hadoop/src/main/java/com/paypal/dione/avro/hadoop/file/AvroBtreeFileUtils.java
+++ b/dione-hadoop/src/main/java/com/paypal/dione/avro/hadoop/file/AvroBtreeFileUtils.java
@@ -1,0 +1,23 @@
+package com.paypal.dione.avro.hadoop.file;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class AvroBtreeFileUtils {
+
+    private AvroBtreeFileUtils() {}
+
+    public static class LRUCache extends LinkedHashMap {
+        private int size;
+
+        public LRUCache(int size) {
+            super(size, 0.75f, true);
+            this.size = size;
+        }
+
+        @Override
+        protected boolean removeEldestEntry(Map.Entry eldest) {
+            return size() > size;
+        }
+    }
+}

--- a/dione-hadoop/src/main/scala/com/paypal/dione/kvstorage/hadoop/avro/AvroBtreeStorageFile.scala
+++ b/dione-hadoop/src/main/scala/com/paypal/dione/kvstorage/hadoop/avro/AvroBtreeStorageFile.scala
@@ -107,8 +107,15 @@ case class AvroBtreeStorageFileReader(override val path: String)
   private def createReaderFrom(path: String) = {
     logger.info(s"Opening avro file: " + path)
 
+    val conf = new Configuration()
+//    conf.set("spark.hadoop.fs.s3a.aws.credentials.provider",
+//      "com.amazonaws.auth.DefaultAWSCredentialsProviderChain")
+//    conf.set("spark.hadoop.fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
+//    conf.set("spark.hadoop.fs.s3a.committer.magic.enabled", "true")
+//    conf.set("spark.hadoop.fs.s3a.committer.name", "magic")
+
     val options = new AvroBtreeFile.Reader.Options()
-      .withConfiguration(new Configuration())
+      .withConfiguration(conf)
       .withPath(new Path(path))
 
     new AvroBtreeFile.Reader(options)

--- a/dione-hadoop/src/main/scala/com/paypal/dione/kvstorage/hadoop/avro/AvroBtreeStorageFile.scala
+++ b/dione-hadoop/src/main/scala/com/paypal/dione/kvstorage/hadoop/avro/AvroBtreeStorageFile.scala
@@ -117,6 +117,7 @@ case class AvroBtreeStorageFileReader(override val path: String)
     val options = new AvroBtreeFile.Reader.Options()
       .withConfiguration(conf)
       .withPath(new Path(path))
+      .withCache(100)
 
     new AvroBtreeFile.Reader(options)
   }

--- a/dione-hadoop/src/main/scala/com/paypal/dione/kvstorage/hadoop/avro/AvroHashBtreeStorageFolderReader.scala
+++ b/dione-hadoop/src/main/scala/com/paypal/dione/kvstorage/hadoop/avro/AvroHashBtreeStorageFolderReader.scala
@@ -47,9 +47,9 @@ case class AvroHashBtreeStorageFolderReader(folderName: String, fileList: List[S
     getFile(numFile)
   }
 
-  private def getFile(numFile: Int): AvroBtreeStorageFileReader = {
+  private def getFile(numFile: Int, cacheSize: Int = 0): AvroBtreeStorageFileReader = {
     val kvStorageFilename = new Path(folderName, fileList(numFile)).toString
-    AvroBtreeStorageFileReader(kvStorageFilename)
+    AvroBtreeStorageFileReader(kvStorageFilename, cacheSize)
   }
 
   override def getIterator(key: Seq[Any]): Iterator[GenericRecord] = {

--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,11 @@
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-aws</artifactId>
+            <version>${hadoop.version}</version>
+        </dependency>
     </dependencies>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -143,11 +143,6 @@
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-aws</artifactId>
-            <version>${hadoop.version}</version>
-        </dependency>
     </dependencies>
 
     <distributionManagement>


### PR DESCRIPTION
## Summary

Adding LRU cache mechanism for reading ahead following blocks and potentially reducing expensive seek operations.
This will be more noticeable for full file sorted-iteration.

## Detailed Description
Added an LRU cache in the Avro B-tree Reader's sorted iterator.

## How was it tested?
added a unit test
 